### PR TITLE
Use same protected `_rest_likes` meta key for all object types

### DIFF
--- a/classes/Comments.php
+++ b/classes/Comments.php
@@ -29,16 +29,6 @@ class Comments extends Controller {
 	protected static $object_type = 'comment';
 
 	/**
-	 * REST field & meta key value.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @var string
-	 */
-	protected $meta_key = 'rest_comment_likes';
-
-	/**
 	 * Adds WordPress hooks.
 	 *
 	 * This includes the regular Controller hooks as well as hooks

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -37,7 +37,7 @@ abstract class Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $meta_key = 'rest_likes';
+	protected $meta_key = '_rest_likes';
 
 	/**
 	 * REST namespace.

--- a/classes/Posts.php
+++ b/classes/Posts.php
@@ -29,16 +29,6 @@ class Posts extends Controller {
 	protected static $object_type = 'post';
 
 	/**
-	 * REST field & meta key value.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @var string
-	 */
-	protected $meta_key = 'rest_post_likes';
-
-	/**
 	 * Adds WordPress hooks.
 	 *
 	 * This includes the regular Controller hooks as well as hooks


### PR DESCRIPTION
Note: On sites where the plugin is already active we need to migrate the meta keys to the new name.

Fixes #39.